### PR TITLE
Potential fix for code scanning alert no. 5: Flask app is run in debug mode

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         print("=" * 60)
         print(f"📁 Working Directory: {current_dir}")
         print(f"🌍 Environment: Development")
-        print(f"🔧 Debug Mode: Enabled")
+        print(f"🔧 Debug Mode: Disabled")
         print(f"🌐 URL: http://localhost:5000")
         print(f"📊 Database: {app.config.get('SQLALCHEMY_DATABASE_URI', 'Not configured')}")
         print("=" * 60)
@@ -65,9 +65,9 @@ if __name__ == "__main__":
         app.run(
             host='0.0.0.0',  # Allow external connections
             port=5001,  # Custom port to avoid conflicts
-            debug=True,
+            debug=False,
             use_reloader=True,
-            use_debugger=True
+            use_debugger=False
         )
         
     except ImportError as e:


### PR DESCRIPTION
Potential fix for [https://github.com/Jaimikoko/acidtech-cashflow-app/security/code-scanning/5](https://github.com/Jaimikoko/acidtech-cashflow-app/security/code-scanning/5)

To fix the problem, you should ensure that the Flask app is not run in debug mode and the interactive debugger is not enabled when the server is accessible externally. The best way to do this is to set `debug=False` and `use_debugger=False` in the `app.run()` call. Additionally, you should consider restricting the host to `127.0.0.1` for development, but since the main issue flagged is debug mode, the minimal fix is to disable debug mode and the debugger.

Edit the `app.run()` call in `dev_server.py` (lines 65-71) to set `debug=False` and `use_debugger=False`. Update the print statements to reflect that debug mode is disabled.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
