### PR TITLE
Validate configuration via init_app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -39,6 +39,7 @@ def create_app(config_name=None):
     # Load configuration
     from config import config
     app.config.from_object(config[config_name])
+    config['production'].init_app(app)
     
     logger.info(f"Database URI: {app.config.get('SQLALCHEMY_DATABASE_URI', 'Not set')}")
     

--- a/config.py
+++ b/config.py
@@ -5,9 +5,6 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 load_dotenv(os.path.join(basedir, '.env'))
 
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-key-acidtech-2024-change-in-production'
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
-        'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.path.join(basedir, 'static', 'uploads')
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB max file size
@@ -24,26 +21,37 @@ class Config:
     AZURE_STORAGE_CONNECTION_STRING = os.environ.get('AZURE_STORAGE_CONNECTION_STRING')
     AZURE_KEY_VAULT_URL = os.environ.get('AZURE_KEY_VAULT_URL')
     APPINSIGHTS_CONNECTION_STRING = os.environ.get('APPINSIGHTS_CONNECTION_STRING')
+
+    @classmethod
+    def init_app(cls, app):
+        """Initialize common configuration values."""
+        app.config['SECRET_KEY'] = os.environ.get(
+            'SECRET_KEY', 'dev-secret-key-acidtech-2024-change-in-production'
+        )
+        app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL') or \
+            'sqlite:///' + os.path.join(basedir, 'app.db')
     
 class DevelopmentConfig(Config):
     DEBUG = True
 
 class ProductionConfig(Config):
     DEBUG = False
-    
+
     # Security enhancements for production
     SESSION_COOKIE_SECURE = True  # HTTPS only
     SESSION_COOKIE_HTTPONLY = True  # Prevent XSS
     SESSION_COOKIE_SAMESITE = 'Lax'  # CSRF protection
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour session timeout
-    
-    # Force strong secret key in production - Fix: Use class attribute
-    @property
-    def SECRET_KEY(self):
-        key = os.environ.get('SECRET_KEY')
-        if not key or key == 'dev-secret-key-acidtech-2024-change-in-production':
-            raise ValueError("Must set SECRET_KEY environment variable in production!")
-        return key
+
+    @classmethod
+    def init_app(cls, app):
+        """Validate required configuration for production."""
+        super().init_app(app)
+        if not app.debug and not app.testing:
+            if app.config['SECRET_KEY'] == 'dev-secret-key-acidtech-2024-change-in-production':
+                raise ValueError('SECRET_KEY is required')
+            if app.config['SQLALCHEMY_DATABASE_URI'].startswith('sqlite:///'):
+                raise ValueError('DATABASE_URL is required')
 
 config = {
     'development': DevelopmentConfig,


### PR DESCRIPTION
## Summary
- Centralize SECRET_KEY and database URI loading in `Config.init_app`
- Add production-only validations for required environment variables
- Invoke production config initialization in application factory

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_b_68977d6cadec832398d96631bd82304c