### PR TITLE
Use migrations in production

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ import os
 import logging
 from datetime import datetime
 from flask import Flask, jsonify
-from flask_migrate import Migrate
+from flask_migrate import Migrate, upgrade
 from flask_login import LoginManager
 
 # Configure basic logging for production compatibility
@@ -118,8 +118,12 @@ def create_app(config_name=None):
     # Initialize database tables
     with app.app_context():
         try:
-            db.create_all()
-            logger.info("Database tables created/verified")
+            if app.config.get('ENV') == 'production':
+                upgrade()
+                logger.info("Database migrations applied")
+            else:
+                db.create_all()
+                logger.info("Database tables created/verified")
         except Exception as e:
             logger.error(f"Database initialization failed: {e}")
             # Don't raise here, let the app start anyway


### PR DESCRIPTION
## Summary
- initialize db with `flask db upgrade` in production
- only call `db.create_all()` for development and testing environments

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_b_6897bb907c7083239b7197ae0eae1e17