### PR TITLE
Use connection context manager in health check route

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from flask import Flask, jsonify
 from flask_migrate import Migrate, upgrade
 from flask_login import LoginManager
+from sqlalchemy import text
 
 # Configure basic logging for production compatibility
 import logging
@@ -134,7 +135,8 @@ def create_app(config_name=None):
         try:
             # Test database connection
             from database import db
-            db.engine.connect()
+            with db.engine.connect() as conn:
+                conn.execute(text('SELECT 1'))
             return jsonify({
                 'status': 'healthy',
                 'database': 'connected',


### PR DESCRIPTION
## Summary
- use SQLAlchemy `text` query within context-managed connection in `/health`
- import `text` from SQLAlchemy for database connectivity check

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6897be1fac7483238d7d1a87c83a8a3b