### PR TITLE
Add Flask-WTF authentication forms with CSRF protection

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,26 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, BooleanField, SubmitField
+from wtforms.validators import DataRequired, Email, Length, Regexp
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    remember_me = BooleanField('Remember me')
+    submit = SubmitField('Sign In')
+
+
+class RegistrationForm(FlaskForm):
+    first_name = StringField('First Name', validators=[DataRequired()])
+    last_name = StringField('Last Name', validators=[DataRequired()])
+    username = StringField('Username', validators=[DataRequired(), Length(min=3)])
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    password = PasswordField(
+        'Password',
+        validators=[
+            DataRequired(),
+            Length(min=8),
+            Regexp(r'.*\d.*', message='Password must contain at least one number'),
+        ],
+    )
+    submit = SubmitField('Create Account')

--- a/app/routes/main/routes.py
+++ b/app/routes/main/routes.py
@@ -1,4 +1,14 @@
-from flask import render_template, render_template_string, request, jsonify, send_from_directory, current_app, flash, redirect, url_for
+from flask import (
+    render_template,
+    render_template_string,
+    request,
+    jsonify,
+    send_from_directory,
+    current_app,
+    flash,
+    redirect,
+    url_for,
+)
 from flask_login import login_required, current_user
 from datetime import datetime, date, timedelta
 from models.transaction import Transaction
@@ -11,6 +21,7 @@ import time
 import logging
 
 from . import main_bp
+from app.forms import LoginForm
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
@@ -27,9 +38,10 @@ def index():
     # If user is already logged in, redirect to dashboard
     if current_user.is_authenticated:
         return redirect(url_for('main.dashboard'))
-    
+
+    form = LoginForm()
     # If not authenticated, show login page
-    return render_template('auth/login_main.html')
+    return render_template('auth/login_main.html', form=form)
 
 @main_bp.route('/dashboard')
 @login_required

--- a/config.py
+++ b/config.py
@@ -5,18 +5,21 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 load_dotenv(os.path.join(basedir, '.env'))
 
 class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key-acidtech-2024-change-in-production')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
+        'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.path.join(basedir, 'static', 'uploads')
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB max file size
-    
+
     # Database connection monitoring
     SHOW_DB_WARNING = os.environ.get('SHOW_DB_WARNING', 'false').lower() == 'true'
-    
+
     # File Mode Configuration for QA Testing
     USE_FILE_MODE = os.environ.get('USE_FILE_MODE', 'false').lower() == 'true'
     EXCEL_DATA_PATH = os.path.join(basedir, 'static', 'uploads', 'qa_data.xlsx')
     TEMP_UPLOAD_PATH = os.environ.get('TEMP_UPLOAD_PATH', '/tmp' if os.name != 'nt' else os.path.join(basedir, 'temp'))
-    
+
     # Azure Configuration
     AZURE_STORAGE_CONNECTION_STRING = os.environ.get('AZURE_STORAGE_CONNECTION_STRING')
     AZURE_KEY_VAULT_URL = os.environ.get('AZURE_KEY_VAULT_URL')
@@ -25,11 +28,7 @@ class Config:
     @classmethod
     def init_app(cls, app):
         """Initialize common configuration values."""
-        app.config['SECRET_KEY'] = os.environ.get(
-            'SECRET_KEY', 'dev-secret-key-acidtech-2024-change-in-production'
-        )
-        app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL') or \
-            'sqlite:///' + os.path.join(basedir, 'app.db')
+        pass
     
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -17,26 +17,32 @@
             </p>
         </div>
         <form class="mt-4" method="POST">
+            {{ form.csrf_token }}
+            {% for field, errors in form.errors.items() %}
+                {% for error in errors %}
+                    <div class="alert alert-danger">{{ error }}</div>
+                {% endfor %}
+            {% endfor %}
             <div class="mb-3">
                 <div>
                     <label for="username" class="sr-only">Username</label>
-                    <input id="username" name="username" type="text" required 
-                           class="form-control" 
-                           placeholder="Username">
+                    <input id="username" name="username" type="text" required
+                           class="form-control"
+                           placeholder="Username" value="{{ form.username.data }}">
                 </div>
             </div>
             <div class="mb-3">
                     <label for="password" class="sr-only">Password</label>
-                    <input id="password" name="password" type="password" required 
-                           class="form-control" 
+                    <input id="password" name="password" type="password" required
+                           class="form-control"
                            placeholder="Password">
             </div>
             </div>
 
             <div class="mb-3 d-flex align-items-center justify-content-between">
                 <div class="form-check">
-                    <input id="remember_me" name="remember_me" type="checkbox" 
-                           class="form-check-input">
+                    <input id="remember_me" name="remember_me" type="checkbox"
+                           class="form-check-input" {% if form.remember_me.data %}checked{% endif %}>
                     <label for="remember_me" class="form-check-label small">
                         Remember me
                     </label>

--- a/templates/auth/login_main.html
+++ b/templates/auth/login_main.html
@@ -190,27 +190,33 @@
             
             <!-- Login Form -->
             <form method="POST" action="{{ url_for('auth.login') }}">
+                {{ form.csrf_token }}
+                {% for field, errors in form.errors.items() %}
+                    {% for error in errors %}
+                        <div class="alert alert-danger">{{ error }}</div>
+                    {% endfor %}
+                {% endfor %}
                 <div class="form-floating">
-                    <input type="text" class="form-control" id="username" name="username" placeholder="Username" required>
+                    <input type="text" class="form-control" id="username" name="username" placeholder="Username" required value="{{ form.username.data }}">
                     <label for="username">
                         <i class="fas fa-user me-2"></i>Username
                     </label>
                 </div>
-                
+
                 <div class="form-floating">
                     <input type="password" class="form-control" id="password" name="password" placeholder="Password" required>
                     <label for="password">
                         <i class="fas fa-lock me-2"></i>Password
                     </label>
                 </div>
-                
+
                 <div class="form-check remember-me">
-                    <input class="form-check-input" type="checkbox" id="remember_me" name="remember_me">
+                    <input class="form-check-input" type="checkbox" id="remember_me" name="remember_me" {% if form.remember_me.data %}checked{% endif %}>
                     <label class="form-check-label" for="remember_me">
                         Remember me
                     </label>
                 </div>
-                
+
                 <button type="submit" class="btn btn-login">
                     <i class="fas fa-sign-in-alt me-2"></i>
                     Sign In

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -17,40 +17,46 @@
             </p>
         </div>
         <form class="mt-4" method="POST">
+            {{ form.csrf_token }}
+            {% for field, errors in form.errors.items() %}
+                {% for error in errors %}
+                    <div class="alert alert-danger">{{ error }}</div>
+                {% endfor %}
+            {% endfor %}
             <div>
                 <div class="row mb-3">
                     <div class="col-6">
                         <label for="first_name" class="form-label small">First Name</label>
-                        <input id="first_name" name="first_name" type="text" required 
-                               class="form-control" 
-                               placeholder="First Name">
+                        <input id="first_name" name="first_name" type="text" required
+                               class="form-control"
+                               placeholder="First Name" value="{{ form.first_name.data }}">
                     </div>
                     <div class="col-6">
                         <label for="last_name" class="form-label small">Last Name</label>
-                        <input id="last_name" name="last_name" type="text" required 
-                               class="form-control" 
-                               placeholder="Last Name">
+                        <input id="last_name" name="last_name" type="text" required
+                               class="form-control"
+                               placeholder="Last Name" value="{{ form.last_name.data }}">
                     </div>
                 </div>
                 
                 <div class="mb-3">
                     <label for="username" class="form-label small">Username</label>
-                    <input id="username" name="username" type="text" required 
-                           class="form-control" 
-                           placeholder="Username">
+                    <input id="username" name="username" type="text" required
+                           class="form-control"
+                           placeholder="Username" value="{{ form.username.data }}">
                 </div>
                 
                 <div class="mb-3">
                     <label for="email" class="form-label small">Email Address</label>
-                    <input id="email" name="email" type="email" required 
-                           class="form-control" 
-                           placeholder="Email address">
+                    <input id="email" name="email" type="email" required
+                           class="form-control"
+                           placeholder="Email address" value="{{ form.email.data }}">
                 </div>
                 
                 <div class="mb-3">
                     <label for="password" class="form-label small">Password</label>
-                    <input id="password" name="password" type="password" required 
-                           class="form-control" 
+                    <input id="password" name="password" type="password" required
+                           class="form-control"
                            placeholder="Password">
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add LoginForm and RegistrationForm via Flask-WTF
- secure forms with SECRET_KEY-based CSRF tokens
- refactor auth routes and templates to use form validation and display errors

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'requests')

------
https://chatgpt.com/codex/tasks/task_b_6897cd35f4ac8323b717356fd6b32aff