### PR TITLE
Use safe default secret key for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ AZURE_KEY_VAULT_URL=https://your-keyvault.vault.azure.net/
 APPINSIGHTS_CONNECTION_STRING=your-app-insights-connection-string
 ```
 
+> **Nota:** En producción, `SECRET_KEY` siempre debe establecerse mediante una variable de entorno. La clave por defecto `dev-secret-key` se utiliza únicamente para desarrollo.
+
 ## 📊 Sample Data
 
 The application includes comprehensive sample data:

--- a/config.py
+++ b/config.py
@@ -25,9 +25,9 @@ class Config:
     @classmethod
     def init_app(cls, app):
         """Initialize common configuration values."""
-        app.config['SECRET_KEY'] = os.environ.get(
-            'SECRET_KEY', 'dev-secret-key-acidtech-2024-change-in-production'
-        )
+        # Use a fixed secret key for development when none is provided.
+        # In production this must be overridden via the SECRET_KEY environment variable.
+        app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev-secret-key')
         app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL') or \
             'sqlite:///' + os.path.join(basedir, 'app.db')
     
@@ -48,7 +48,7 @@ class ProductionConfig(Config):
         """Validate required configuration for production."""
         super().init_app(app)
         if not app.debug and not app.testing:
-            if app.config['SECRET_KEY'] == 'dev-secret-key-acidtech-2024-change-in-production':
+            if app.config['SECRET_KEY'] == 'dev-secret-key':
                 raise ValueError('SECRET_KEY is required')
             if app.config['SQLALCHEMY_DATABASE_URI'].startswith('sqlite:///'):
                 raise ValueError('DATABASE_URL is required')


### PR DESCRIPTION
## Summary
- provide a fixed development secret key when `SECRET_KEY` is unset
- note in documentation that production must set `SECRET_KEY` via environment variable

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6897d038139083239cc244f67467a77f