### PR TITLE
Allow disabling secure cookies for local testing

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,7 +37,7 @@ class ProductionConfig(Config):
     DEBUG = False
 
     # Security enhancements for production
-    SESSION_COOKIE_SECURE = True  # HTTPS only
+    SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'true').lower() == 'true'  # HTTPS only
     SESSION_COOKIE_HTTPONLY = True  # Prevent XSS
     SESSION_COOKIE_SAMESITE = 'Lax'  # CSRF protection
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour session timeout


### PR DESCRIPTION
## Summary
- Make `SESSION_COOKIE_SECURE` configurable via `SESSION_COOKIE_SECURE` environment variable

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6897da0673848323adfbb85d5a7b69bf