### PR TITLE
Fix debug startup and enforce env config

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,40 +4,77 @@ from dotenv import load_dotenv
 basedir = os.path.abspath(os.path.dirname(__file__))
 load_dotenv(os.path.join(basedir, '.env'))
 
+# Determine if running in production
+IS_PRODUCTION = os.getenv('FLASK_CONFIG') == 'production' or bool(os.getenv('WEBSITE_SITE_NAME'))
+
+# Resolve database URI
+_database_uri = os.getenv('DATABASE_URL') or os.getenv('SQLALCHEMY_DATABASE_URI')
+if IS_PRODUCTION and not _database_uri:
+    raise ValueError('DATABASE_URL is required in production')
+
+
 class Config:
     """Base configuration loaded from environment variables."""
-    SECRET_KEY = os.environ.get('SECRET_KEY', os.urandom(24))
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
-        'sqlite:///' + os.path.join(basedir, 'app.db')
+    SECRET_KEY = os.getenv('SECRET_KEY') or os.urandom(24)
+    SQLALCHEMY_DATABASE_URI = _database_uri or 'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
     UPLOAD_FOLDER = os.path.join(basedir, 'static', 'uploads')
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB max file size
-    
+
     # Database connection monitoring
-    SHOW_DB_WARNING = os.environ.get('SHOW_DB_WARNING', 'false').lower() == 'true'
-    
+    SHOW_DB_WARNING = os.getenv('SHOW_DB_WARNING', 'false').lower() == 'true'
+
     # File Mode Configuration for QA Testing
-    USE_FILE_MODE = os.environ.get('USE_FILE_MODE', 'false').lower() == 'true'
+    USE_FILE_MODE = os.getenv('USE_FILE_MODE', 'false').lower() == 'true'
     EXCEL_DATA_PATH = os.path.join(basedir, 'static', 'uploads', 'qa_data.xlsx')
-    TEMP_UPLOAD_PATH = os.environ.get('TEMP_UPLOAD_PATH', '/tmp' if os.name != 'nt' else os.path.join(basedir, 'temp'))
-    
+    TEMP_UPLOAD_PATH = os.getenv('TEMP_UPLOAD_PATH', '/tmp' if os.name != 'nt' else os.path.join(basedir, 'temp'))
+
     # Azure Configuration
-    AZURE_STORAGE_CONNECTION_STRING = os.environ.get('AZURE_STORAGE_CONNECTION_STRING')
-    AZURE_KEY_VAULT_URL = os.environ.get('AZURE_KEY_VAULT_URL')
-    APPINSIGHTS_CONNECTION_STRING = os.environ.get('APPINSIGHTS_CONNECTION_STRING')
-    
+    AZURE_STORAGE_CONNECTION_STRING = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
+    AZURE_KEY_VAULT_URL = os.getenv('AZURE_KEY_VAULT_URL')
+    APPINSIGHTS_CONNECTION_STRING = os.getenv('APPINSIGHTS_CONNECTION_STRING')
+
+    # Default cookie and security settings
+    SESSION_COOKIE_SECURE = False
+    REMEMBER_COOKIE_SECURE = False
+    SESSION_COOKIE_HTTPONLY = True
+    REMEMBER_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = 'Lax'
+    WTF_CSRF_ENABLED = True
+    PERMANENT_SESSION_LIFETIME = 3600
+
+    @classmethod
+    def init_app(cls, app):
+        """Initialize common configuration values."""
+        pass
+
+
 class DevelopmentConfig(Config):
     DEBUG = True
+    SESSION_COOKIE_SECURE = False
+    REMEMBER_COOKIE_SECURE = False
+
+
+class TestingConfig(Config):
+    TESTING = True
+    SECRET_KEY = 'testing-secret'
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    WTF_CSRF_ENABLED = False
+    SESSION_COOKIE_SECURE = False
+    REMEMBER_COOKIE_SECURE = False
+
 
 class ProductionConfig(Config):
     DEBUG = False
-    
+
     # Security enhancements for production
     SESSION_COOKIE_SECURE = True  # HTTPS only
     SESSION_COOKIE_HTTPONLY = True  # Prevent XSS
     SESSION_COOKIE_SAMESITE = 'Lax'  # CSRF protection
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour session timeout
-    
+    REMEMBER_COOKIE_SECURE = True
+
     # Force strong secrets and database configuration in production
     @property
     def SECRET_KEY(self):
@@ -48,13 +85,14 @@ class ProductionConfig(Config):
 
     @property
     def SQLALCHEMY_DATABASE_URI(self):
-        uri = os.environ.get('DATABASE_URL')
-        if not uri:
+        if not _database_uri:
             raise ValueError("Must set DATABASE_URL environment variable in production!")
-        return uri
+        return _database_uri
+
 
 config = {
     'development': DevelopmentConfig,
+    'testing': TestingConfig,
     'production': ProductionConfig,
-    'default': DevelopmentConfig
+    'default': DevelopmentConfig,
 }

--- a/config.py
+++ b/config.py
@@ -5,7 +5,8 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 load_dotenv(os.path.join(basedir, '.env'))
 
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-key-acidtech-2024-change-in-production'
+    """Base configuration loaded from environment variables."""
+    SECRET_KEY = os.environ.get('SECRET_KEY', os.urandom(24))
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -37,13 +38,20 @@ class ProductionConfig(Config):
     SESSION_COOKIE_SAMESITE = 'Lax'  # CSRF protection
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour session timeout
     
-    # Force strong secret key in production - Fix: Use class attribute
+    # Force strong secrets and database configuration in production
     @property
     def SECRET_KEY(self):
         key = os.environ.get('SECRET_KEY')
-        if not key or key == 'dev-secret-key-acidtech-2024-change-in-production':
+        if not key:
             raise ValueError("Must set SECRET_KEY environment variable in production!")
         return key
+
+    @property
+    def SQLALCHEMY_DATABASE_URI(self):
+        uri = os.environ.get('DATABASE_URL')
+        if not uri:
+            raise ValueError("Must set DATABASE_URL environment variable in production!")
+        return uri
 
 config = {
     'development': DevelopmentConfig,

--- a/startup.py
+++ b/startup.py
@@ -83,28 +83,23 @@ def test_database_connection(app):
         return False
 
 def run_gunicorn():
-    """Run gunicorn with optimal settings for Azure App Service."""
+    """Run gunicorn with production-ready settings."""
     logger.info("=== STARTING GUNICORN SERVER ===")
-    
-    port = os.environ.get('PORT', '8000')
-    workers = os.environ.get('GUNICORN_WORKERS', '1')  # Azure App Service works better with 1 worker
-    
+
+    port = os.environ.get("PORT", "5001")
+
     cmd = [
-        'gunicorn',
-        '--bind', f'0.0.0.0:{port}',
-        '--timeout', '600',
-        '--workers', workers,
-        '--access-logfile', '-',
-        '--error-logfile', '-',
-        '--log-level', 'info',
-        'wsgi:app'
+        "gunicorn",
+        "--bind", f"0.0.0.0:{port}",
+        "--timeout", "600",
+        "wsgi:app",
     ]
-    
+
     logger.info(f"Gunicorn command: {' '.join(cmd)}")
-    
+
     try:
         # Use exec to replace the current process
-        os.execvp('gunicorn', cmd)
+        os.execvp("gunicorn", cmd)
     except Exception as e:
         logger.error(f"Failed to start gunicorn: {e}")
         sys.exit(1)
@@ -135,3 +130,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,17 @@
+# Summary
+
+## Problem we had
+Flask app in debug mode and outdated Plotly script causing console warning, security risk
+
+## What we changed
+- Disabled debug mode and enforced secure startup configuration
+- Ensured SECRET_KEY and database configuration load from environment variables
+- Enforced gunicorn startup `gunicorn --bind=0.0.0.0 --timeout 600 wsgi:app`
+- Replaced deprecated Plotly reference with version 2.27.0 and loaded it only on pages needing charts
+
+## Current status
+Ready for production with secure startup and up-to-date charting library
+
+## Next steps
+- Deployment testing on Azure
+- Logging verification

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,9 +11,6 @@
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
-    <!-- Chart.js -->
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-    
     <!-- Custom Styles -->
     <link href="{{ url_for('static', filename='css/styles.css') }}" rel="stylesheet">
     

--- a/templates/reports/aging.html
+++ b/templates/reports/aging.html
@@ -181,6 +181,8 @@
 {% endblock %}
 
 {% block scripts %}
+    <!-- Load Plotly 2.27.0; clear browser cache if older version persists -->
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Aging chart

--- a/templates/reports/ai_insights.html
+++ b/templates/reports/ai_insights.html
@@ -243,6 +243,8 @@
 {% endblock %}
 
 {% block scripts %}
+    <!-- Load Plotly 2.27.0; clear browser cache if older version persists -->
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Cash flow forecast chart

--- a/templates/reports/cash_flow.html
+++ b/templates/reports/cash_flow.html
@@ -180,6 +180,8 @@
 {% endblock %}
 
 {% block scripts %}
+    <!-- Load Plotly 2.27.0; clear browser cache if older version persists -->
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Cash flow chart data from backend

--- a/templates/reports/vendor_analysis.html
+++ b/templates/reports/vendor_analysis.html
@@ -237,6 +237,8 @@
 {% endblock %}
 
 {% block scripts %}
+    <!-- Load Plotly 2.27.0; clear browser cache if older version persists -->
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Top vendors chart

--- a/wsgi.py
+++ b/wsgi.py
@@ -42,8 +42,16 @@ except Exception as e:
     raise
 
 if __name__ == "__main__":
-    # Azure uses PORT environment variable, defaulting to 8000 for local dev
-    port = int(os.environ.get('PORT', 8000))
-    host = os.environ.get('HOST', '0.0.0.0')
+    # Respect environment variables but provide sensible defaults for local use
+    port = int(os.environ.get("PORT", 5001))
+    host = os.environ.get("HOST", "0.0.0.0")
+    use_reloader = os.environ.get("FLASK_ENV") == "development"
+
     logger.info(f"Starting Flask app on {host}:{port}")
-    app.run(host=host, port=port, debug=False)
+    app.run(
+        host=host,
+        port=port,
+        debug=False,
+        use_debugger=False,
+        use_reloader=use_reloader,
+    )


### PR DESCRIPTION
## Summary
- Ensure production config loads secrets and database URIs from environment variables
- Disable debug mode in WSGI entrypoint and default to port 5001
- Simplify startup to run gunicorn with secure defaults
- Replace deprecated plotly-latest script with Plotly 2.27.0 and load charts only on report templates

## Testing
- `python -m py_compile config.py startup.py wsgi.py`
- `python - <<'PY'
from app import create_app
app = create_app('development')
client = app.test_client()
client.get('/')
PY`

------
https://chatgpt.com/codex/tasks/task_b_689768dcd12083239703dc87c9c3316e