### PR TITLE
Potential fix for code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/templates/accounts_payable/create.html
+++ b/templates/accounts_payable/create.html
@@ -117,7 +117,8 @@ document.addEventListener('DOMContentLoaded', function() {
         if (file) {
             const fileInfo = document.createElement('div');
             fileInfo.className = 'small text-success mt-2';
-            fileInfo.innerHTML = `<i class="fas fa-check me-1"></i>Selected: ${file.name}`;
+            fileInfo.innerHTML = `<i class="fas fa-check me-1"></i>Selected: `;
+            fileInfo.appendChild(document.createTextNode(file.name));
             
             // Remove previous file info
             const existingInfo = document.querySelector('.file-info');


### PR DESCRIPTION
Potential fix for [https://github.com/Jaimikoko/acidtech-cashflow-app/security/code-scanning/25](https://github.com/Jaimikoko/acidtech-cashflow-app/security/code-scanning/25)

To fix the problem, we should ensure that the file name is not interpreted as HTML. The best way to do this is to escape the file name before inserting it into the DOM, or, even better, to avoid using `innerHTML` altogether and use `textContent` for the file name portion. Since the markup includes an icon and some static text, we can safely set the icon and static text using `innerHTML`, but the file name should be inserted as a text node to prevent any possibility of XSS.

**Detailed fix:**  
- In the file templates/accounts_payable/create.html, in the script block, replace the assignment to `fileInfo.innerHTML` with code that sets the icon and static text using `innerHTML`, and then appends the file name as a text node using `textContent` or `createTextNode`.
- This change should be made on line 120.
- No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
