### PR TITLE
Potential fix for code scanning alert no. 28: URL redirection from remote source

### DIFF
--- a/app/routes/auth/routes.py
+++ b/app/routes/auth/routes.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from flask import render_template, request, url_for, redirect, flash, current_app, session
+from urllib.parse import urlparse
 from flask_login import login_user, logout_user, login_required, current_user
 
 from models.user import User
@@ -31,7 +32,13 @@ def login():
 
             # Safe redirect
             next_url = request.args.get('next')
-            if not next_url or not next_url.startswith('/'):
+            # Sanitize and validate next_url to prevent open redirect
+            if next_url:
+                next_url = next_url.replace('\\', '')
+                parsed_url = urlparse(next_url)
+                if parsed_url.netloc or parsed_url.scheme or not next_url.startswith('/'):
+                    next_url = url_for('main.dashboard')
+            else:
                 next_url = url_for('main.dashboard')
             current_app.logger.info(f'Login OK for {username}; redirecting to {next_url}')
             return redirect(next_url)


### PR DESCRIPTION
Potential fix for [https://github.com/Jaimikoko/acidtech-cashflow-app/security/code-scanning/28](https://github.com/Jaimikoko/acidtech-cashflow-app/security/code-scanning/28)

To fix the problem, we should ensure that the value of `next_url` is a safe, relative path and cannot be used to redirect users to an external site. The best way to do this is to use the `urlparse` function from Python's standard library to parse the URL, remove any backslashes, and check that both the `netloc` and `scheme` attributes are empty. This ensures that the redirect target is a relative path within the application. The fix should be applied in the `login` function, specifically where `next_url` is processed (lines 33–37). We will need to import `urlparse` from `urllib.parse` at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
