### PR TITLE
Install form dependencies during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,15 @@ The application is configured for deployment to Azure App Service with GitHub Ac
 2. **Set up GitHub Secrets**:
    - `AZURE_WEBAPP_PUBLISH_PROFILE`: Download from Azure App Service
 
-3. **Deploy**: Push to the `main` branch to trigger automatic deployment
+3. **Install form dependencies during deployment**
+   - In Azure App Service, set the `POST_BUILD_COMMAND` app setting to run:
+     ```bash
+     pip install Flask-WTF WTForms email-validator
+     ```
+   - Make sure the command includes the package names; leaving `POST_BUILD_COMMAND` empty or set only to `pip install` will cause deployment to fail with `You must give at least one requirement to install`.
+   - After deployment, inspect the build logs for a line similar to `Successfully installed Flask-WTF WTForms email-validator` to confirm the install completed before the app starts.
+
+4. **Deploy**: Push to the `main` branch to trigger automatic deployment
 
 ### Environment Variables
 

--- a/startup.py
+++ b/startup.py
@@ -19,6 +19,30 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+def install_dependencies():
+    """Install form dependencies only if they are missing."""
+    required = ["Flask-WTF", "WTForms", "email-validator"]
+    missing = []
+
+    for pkg in required:
+        try:
+            __import__(pkg.lower().replace("-", "_"))
+        except ImportError:
+            missing.append(pkg)
+
+    if not missing:
+        logger.info("All required dependencies already installed")
+        return
+
+    logger.info("=== INSTALLING REQUIRED DEPENDENCIES ===")
+    cmd = [sys.executable, "-m", "pip", "install", *missing]
+    try:
+        subprocess.check_call(cmd)
+        logger.info("✅ Dependency installation complete")
+    except subprocess.CalledProcessError as e:
+        logger.error(f"❌ Dependency installation failed: {e}")
+        sys.exit(1)
+
 def diagnose_environment():
     """Diagnose the environment and log critical information."""
     logger.info("=== AZURE APP SERVICE STARTUP DIAGNOSTICS ===")
@@ -107,6 +131,9 @@ def run_gunicorn():
 def main():
     """Main startup function."""
     try:
+        # Step 0: Ensure required packages are installed
+        install_dependencies()
+
         # Step 1: Diagnose environment
         diagnose_environment()
         


### PR DESCRIPTION
## Summary
- Ensure Flask-WTF, WTForms, and email-validator are installed at startup if missing
- Document POST_BUILD_COMMAND to install form dependencies during Azure deployment and note that the command must list the packages explicitly

## Testing
- `pip install -r tests/requirements-test.txt` *(failed: Could not find a version that satisfies the requirement requests>=2.28.0)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_689833bca4d88323b8d4a5b6951c5c3e