### PR TITLE
Fix auth/login template and add ProxyFix configuration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,7 @@ from flask import Flask, jsonify
 from flask_migrate import Migrate, upgrade
 from flask_login import LoginManager
 from sqlalchemy import text
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 # Configure basic logging for production compatibility
 import logging
@@ -36,6 +37,7 @@ def create_app(config_name=None):
     static_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'static')
     
     app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
     
     # Load configuration
     from config import config

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,29 +1,239 @@
-{% extends "base.html" %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AcidTech APP - Login</title>
+    
+    <!-- Favicon -->
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
+    
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    
+    <!-- Custom Styles -->
+    <style>
+        :root {
+            --acidtech-dark: #0b0c10;
+            --acidtech-primary: #02d6e2;
+            --acidtech-light: #ffffff;
+            --acidtech-muted: #dcdcdc;
+            --acidtech-hover: #17f0cb;
+        }
+        
+        body {
+            background: linear-gradient(135deg, var(--acidtech-dark) 0%, #1a1b2e 50%, #16213e 100%);
+            min-height: 100vh;
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+        
+        .login-container {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        
+        .login-card {
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(20px);
+            border-radius: 20px;
+            padding: 3rem;
+            box-shadow: 0 25px 50px rgba(0, 0, 0, 0.3);
+            width: 100%;
+            max-width: 450px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+        }
+        
+        .brand-icon {
+            width: 80px;
+            height: 80px;
+            background: linear-gradient(135deg, var(--acidtech-primary), var(--acidtech-hover));
+            border-radius: 20px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 2rem;
+            box-shadow: 0 10px 30px rgba(2, 214, 226, 0.3);
+        }
+        
+        .brand-icon i {
+            font-size: 2rem;
+            color: white;
+        }
+        
+        .login-title {
+            color: var(--acidtech-dark);
+            font-weight: 700;
+            font-size: 1.8rem;
+            text-align: center;
+            margin-bottom: 0.5rem;
+        }
+        
+        .login-subtitle {
+            color: #6c757d;
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+        
+        .form-floating {
+            margin-bottom: 1.5rem;
+        }
+        
+        .form-control {
+            border: 2px solid #e9ecef;
+            border-radius: 12px;
+            padding: 1rem 1.25rem;
+            font-size: 1rem;
+            transition: all 0.3s ease;
+        }
+        
+        .form-control:focus {
+            border-color: var(--acidtech-primary);
+            box-shadow: 0 0 0 0.2rem rgba(2, 214, 226, 0.25);
+        }
+        
+        .btn-login {
+            background: linear-gradient(135deg, var(--acidtech-primary), var(--acidtech-hover));
+            border: none;
+            border-radius: 12px;
+            padding: 1rem;
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: white;
+            width: 100%;
+            transition: all 0.3s ease;
+            margin-top: 1rem;
+        }
+        
+        .btn-login:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 30px rgba(2, 214, 226, 0.4);
+            color: white;
+        }
+        
+        .remember-me {
+            color: #6c757d;
+        }
+        
+        .register-link {
+            text-align: center;
+            margin-top: 2rem;
+            color: #6c757d;
+        }
+        
+        .register-link a {
+            color: var(--acidtech-primary);
+            text-decoration: none;
+            font-weight: 600;
+        }
+        
+        .register-link a:hover {
+            color: var(--acidtech-hover);
+        }
+        
+        /* Flash messages */
+        .alert {
+            border-radius: 12px;
+            border: none;
+            margin-bottom: 1.5rem;
+        }
+        
+        /* Responsive */
+        @media (max-width: 576px) {
+            .login-card {
+                margin: 1rem;
+                padding: 2rem 1.5rem;
+            }
+            
+            .brand-icon {
+                width: 60px;
+                height: 60px;
+            }
+            
+            .brand-icon i {
+                font-size: 1.5rem;
+            }
+            
+            .login-title {
+                font-size: 1.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <div class="login-card">
+            <!-- Brand Icon -->
+            <div class="brand-icon">
+                <i class="fas fa-chart-line"></i>
+            </div>
+            
+            <!-- Title -->
+            <h1 class="login-title">Welcome Back</h1>
+            <p class="login-subtitle">Sign in to your AcidTech APP account</p>
+            
+            <!-- Flash Messages -->
+            {% with messages = get_flashed_messages(with_categories=true) %}
+                {% if messages %}
+                    {% for category, message in messages %}
+                        <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
+                            {{ message }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        </div>
+                    {% endfor %}
+                {% endif %}
+            {% endwith %}
+            
+            <!-- Login Form -->
+            <form method="POST" action="{{ url_for('auth.login') }}">
+                {{ form.csrf_token }}
+                {% for field, errors in form.errors.items() %}
+                    {% for error in errors %}
+                        <div class="alert alert-danger">{{ error }}</div>
+                    {% endfor %}
+                {% endfor %}
+                <div class="form-floating">
+                    <input type="text" class="form-control" id="username" name="username" placeholder="Username" required value="{{ form.username.data }}">
+                    <label for="username">
+                        <i class="fas fa-user me-2"></i>Username
+                    </label>
+                </div>
 
-{% block title %}Login - Cash Flow Management{% endblock %}
+                <div class="form-floating">
+                    <input type="password" class="form-control" id="password" name="password" placeholder="Password" required>
+                    <label for="password">
+                        <i class="fas fa-lock me-2"></i>Password
+                    </label>
+                </div>
 
-{% block content %}
-<form method="post" action="{{ url_for('auth.login', next=request.args.get('next')) }}">
-  {{ form.csrf_token }}
-  <!-- username -->
-  {{ form.username.label }}
-  {{ form.username(class='input') }}
-  {% for e in form.username.errors %}<div class="error">{{ e }}</div>{% endfor %}
+                <div class="form-check remember-me">
+                    <input class="form-check-input" type="checkbox" id="remember_me" name="remember_me" {% if form.remember_me.data %}checked{% endif %}>
+                    <label class="form-check-label" for="remember_me">
+                        Remember me
+                    </label>
+                </div>
 
-  <!-- password -->
-  {{ form.password.label }}
-  {{ form.password(class='input') }}
-  {% for e in form.password.errors %}<div class="error">{{ e }}</div>{% endfor %}
-
-  <!-- remember me -->
-  {{ form.remember_me() }} {{ form.remember_me.label }}
-
-  <button type="submit">Sign In</button>
-
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% for category, message in messages %}
-      <div class="flash {{ category }}">{{ message }}</div>
-    {% endfor %}
-  {% endwith %}
-</form>
-{% endblock %}
+                <button type="submit" class="btn btn-login">
+                    <i class="fas fa-sign-in-alt me-2"></i>
+                    Sign In
+                </button>
+            </form>
+            
+            <!-- Register Link -->
+            <div class="register-link">
+                <p class="mb-0">
+                    Don't have an account? 
+                    <a href="{{ url_for('auth.register') }}">Create one here</a>
+                </p>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace /auth/login template with standalone page including CSRF token and credentials form
- configure ProxyFix middleware on Flask app

## Testing
- `python wsgi.py` (curl /auth/login shows CSRF token and form)
- `pytest` (fails: ModuleNotFoundError: No module named 'requests')

------
https://chatgpt.com/codex/tasks/task_b_6898f4c665c88323986b859f96fd10f5