### PR TITLE
Replace hardcoded dashboard metrics with DB-driven values

### DIFF
--- a/templates/accounts_payable/index.html
+++ b/templates/accounts_payable/index.html
@@ -46,7 +46,7 @@
               Total Outstanding
             </div>
             <div class="h4 mb-0 fw-bold" id="total-outstanding">
-              $425,800
+              {{ ap.total_outstanding|default(0)|currency }}
             </div>
           </div>
           <div class="text-danger">
@@ -67,7 +67,7 @@
               Bills Pending
             </div>
             <div class="h4 mb-0 fw-bold" id="pending-bills">
-              18
+              {{ ap.pending_bills|default(0) }}
             </div>
           </div>
           <div class="text-warning">
@@ -88,7 +88,7 @@
               Payments YTD
             </div>
             <div class="h4 mb-0 fw-bold" id="payments-ytd">
-              $8,750,000
+              {{ ap.total_ytd|default(0)|currency }}
             </div>
           </div>
           <div class="text-primary">
@@ -109,7 +109,7 @@
               Payment Accuracy
             </div>
             <div class="h4 mb-0 fw-bold" id="payment-accuracy">
-              99.2%
+              {{ ap.payment_accuracy|default(0)|round(1) }}%
             </div>
           </div>
           <div class="text-info">
@@ -147,7 +147,7 @@
       <div class="card-body">
         <div class="alert alert-info" role="alert">
           <i class="fas fa-info-circle me-2"></i>
-          <strong>A/P Status:</strong> 18 bills pending payment with excellent 99.2% accuracy rate.
+          <strong>A/P Status:</strong> {{ ap.pending_bills|default(0) }} bills pending payment with excellent {{ ap.payment_accuracy|default(0)|round(1) }}% accuracy rate.
           Strategic vendor relationships maintained for operational continuity.
         </div>
         
@@ -277,7 +277,7 @@
           <div class="col-md-6">
             <h6 class="fw-bold">Payment Performance</h6>
             <p class="text-muted">
-              Our A/P management maintains excellent vendor relationships with 99.2% payment accuracy 
+              Our A/P management maintains excellent vendor relationships with {{ ap.payment_accuracy|default(0)|round(1) }}% payment accuracy
               and average payment time of 25 days. Strategic partnerships with major service providers.
             </p>
           </div>

--- a/templates/accounts_receivable/index.html
+++ b/templates/accounts_receivable/index.html
@@ -46,7 +46,7 @@
               Total Outstanding
             </div>
             <div class="h4 mb-0 fw-bold" id="total-outstanding">
-              $847,250
+              {{ ar.total_outstanding|default(0)|currency }}
             </div>
           </div>
           <div class="text-success">
@@ -67,7 +67,7 @@
               Invoices Pending
             </div>
             <div class="h4 mb-0 fw-bold" id="pending-invoices">
-              24
+              {{ ar.pending_invoices|default(0) }}
             </div>
           </div>
           <div class="text-warning">
@@ -88,7 +88,7 @@
               Collections YTD
             </div>
             <div class="h4 mb-0 fw-bold" id="collections-ytd">
-              $12,450,000
+              {{ ar.total_ytd|default(0)|currency }}
             </div>
           </div>
           <div class="text-primary">
@@ -109,7 +109,7 @@
               Collection Rate
             </div>
             <div class="h4 mb-0 fw-bold" id="collection-rate">
-              96.5%
+              {{ ar.collection_rate|default(0)|round(1) }}%
             </div>
           </div>
           <div class="text-info">
@@ -147,7 +147,7 @@
       <div class="card-body">
         <div class="alert alert-info" role="alert">
           <i class="fas fa-info-circle me-2"></i>
-          <strong>A/R Status:</strong> 24 invoices pending with excellent 96.5% collection rate.
+          <strong>A/R Status:</strong> {{ ar.pending_invoices|default(0) }} invoices pending with excellent {{ ar.collection_rate|default(0)|round(1) }}% collection rate.
           Strong relationships with major Permian Basin operators.
         </div>
         
@@ -277,7 +277,7 @@
           <div class="col-md-6">
             <h6 class="fw-bold">Collection Performance</h6>
             <p class="text-muted">
-              Our A/R management demonstrates excellent performance with a 96.5% collection rate 
+              Our A/R management demonstrates excellent performance with a {{ ar.collection_rate|default(0)|round(1) }}% collection rate
               and average collection time of 28 days. Strong relationships with major operators.
             </p>
           </div>

--- a/templates/cash_flow/classification_dashboard.html
+++ b/templates/cash_flow/classification_dashboard.html
@@ -47,7 +47,7 @@
               Total Transactions
             </div>
             <div class="h4 mb-0 fw-bold">
-              {{ summary.total if summary else '594' }}
+              {{ summary.total if summary else '0' }}
             </div>
           </div>
           <div class="text-success">
@@ -68,7 +68,7 @@
               Classified
             </div>
             <div class="h4 mb-0 fw-bold">
-              {{ summary.classified if summary else '594' }}
+              {{ summary.classified if summary else '0' }}
             </div>
           </div>
           <div class="text-info">
@@ -162,7 +162,7 @@
         {% else %}
         <div class="alert alert-info">
           <i class="fas fa-info-circle me-2"></i>
-          <strong>All transactions classified:</strong> All 594 transactions have been successfully classified by the AI system.
+          <strong>All transactions classified:</strong> All {{ summary.total if summary else 0 }} transactions have been successfully classified by the AI system.
         </div>
         {% endif %}
       </div>

--- a/templates/cash_flow/enhanced_dashboard.html
+++ b/templates/cash_flow/enhanced_dashboard.html
@@ -159,7 +159,7 @@
                     </h3>
                     <p class="kpi-label text-muted mb-0">Total Revenue</p>
                     <span class="trend-indicator trend-up">
-                        <i class="fas fa-arrow-up"></i> +12.5%
+                        <i class="fas fa-arrow-up"></i> {{ trends.inflow_change_pct|default('0%') }}
                     </span>
                 </div>
             </div>
@@ -176,7 +176,7 @@
                     </h3>
                     <p class="kpi-label text-muted mb-0">Total Expenses</p>
                     <span class="trend-indicator trend-down">
-                        <i class="fas fa-arrow-down"></i> -5.2%
+                        <i class="fas fa-arrow-down"></i> {{ trends.outflow_change_pct|default('0%') }}
                     </span>
                 </div>
             </div>
@@ -193,7 +193,7 @@
                     </h3>
                     <p class="kpi-label text-muted mb-0">Net Cash Flow</p>
                     <span class="trend-indicator trend-up">
-                        <i class="fas fa-arrow-up"></i> +18.3%
+                        <i class="fas fa-arrow-up"></i> {{ trends.net_change_pct|default('0%') }}
                     </span>
                 </div>
             </div>

--- a/templates/dashboard/financial_summary.html
+++ b/templates/dashboard/financial_summary.html
@@ -46,7 +46,7 @@
               Total Revenue YTD
             </div>
             <div class="h4 mb-0 fw-bold" id="total-revenue-ytd">
-              $14,647,770
+              {{ kpis.total_revenue_ytd|default(0)|currency }}
             </div>
           </div>
           <div class="text-success">
@@ -67,7 +67,7 @@
               Profit Margin
             </div>
             <div class="h4 mb-0 fw-bold" id="profit-margin">
-              74.5%
+              {{ kpis.profit_margin|default(0)|round(1) }}%
             </div>
           </div>
           <div class="text-info">
@@ -88,7 +88,7 @@
               Net Cash Flow
             </div>
             <div class="h4 mb-0 fw-bold" id="net-cash-flow">
-              $10,906,933
+              {{ kpis.net_cash_flow|default(0)|currency }}
             </div>
           </div>
           <div class="text-primary">
@@ -109,7 +109,7 @@
               Transaction Processing
             </div>
             <div class="h4 mb-0 fw-bold">
-              100%
+              {{ kpis.processing_rate|default('0%') }}
             </div>
           </div>
           <div class="text-warning">
@@ -144,32 +144,32 @@
       <div class="card-body">
         <div class="alert alert-info" role="alert">
           <i class="fas fa-info-circle me-2"></i>
-          <strong>Revenue Growth:</strong> YTD revenue of $14.6M represents strong performance in oil & gas services.
-          Current profit margin of 74.5% indicates excellent operational efficiency.
+          <strong>Revenue Growth:</strong> YTD revenue of {{ kpis.total_revenue_ytd|default(0)|currency }} represents strong performance in oil & gas services.
+          Current profit margin of {{ kpis.profit_margin|default(0)|round(1) }}% indicates excellent operational efficiency.
         </div>
         
         <!-- Quick Stats -->
         <div class="row text-center mb-4">
           <div class="col-md-3 col-6">
             <div class="border-end">
-              <div class="h5 mb-1 text-success fw-bold">594</div>
+              <div class="h5 mb-1 text-success fw-bold">{{ kpis.transactions_processed|default(0) }}</div>
               <small class="text-muted">Transactions Processed</small>
             </div>
           </div>
           <div class="col-md-3 col-6">
             <div class="border-end">
-              <div class="h5 mb-1 text-primary fw-bold">$24,647</div>
+              <div class="h5 mb-1 text-primary fw-bold">{{ kpis.avg_transaction_value|default(0)|currency }}</div>
               <small class="text-muted">Avg Transaction Value</small>
             </div>
           </div>
           <div class="col-md-3 col-6">
             <div class="border-end">
-              <div class="h5 mb-1 text-warning fw-bold">$3.7M</div>
+              <div class="h5 mb-1 text-warning fw-bold">{{ kpis.total_expenses_ytd|default(0)|currency }}</div>
               <small class="text-muted">Total Expenses</small>
             </div>
           </div>
           <div class="col-md-3 col-6">
-            <div class="h5 mb-1 text-info fw-bold">8 months</div>
+            <div class="h5 mb-1 text-info fw-bold">{{ kpis.ytd_months|default(0) }} months</div>
             <small class="text-muted">YTD Coverage</small>
           </div>
         </div>
@@ -202,7 +202,7 @@
               <strong>Revenue Growth</strong>
               <br><small class="text-muted">Year-over-Year</small>
             </div>
-            <span class="badge bg-success rounded-pill">+22.5%</span>
+            <span class="badge bg-success rounded-pill">{{ kpis.revenue_growth|default(0)|round(1) }}%</span>
           </div>
           <div class="list-group-item d-flex justify-content-between align-items-center">
             <div>

--- a/templates/dashboard/main.html
+++ b/templates/dashboard/main.html
@@ -33,9 +33,9 @@
 {% block main_content_title %}Recent Activity{% endblock %}
 {% block main_content_body %}
 <div class="alert alert-info" role="alert">
-  <i class="fas fa-info-circle me-2"></i>
-  <strong>System Status:</strong> All financial systems operational. 594 transactions processed and classified.
-</div>
+    <i class="fas fa-info-circle me-2"></i>
+    <strong>System Status:</strong> All financial systems operational.
+    </div>
 
 <!-- Recent Transactions Table -->
 <div class="table-responsive">

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -46,7 +46,7 @@
               Total Items
             </div>
             <div class="h4 mb-0 fw-bold">
-              124
+              {{ inventory.total_items|default(0) }}
             </div>
           </div>
           <div class="text-primary">
@@ -67,7 +67,7 @@
               Low Stock Items
             </div>
             <div class="h4 mb-0 fw-bold">
-              8
+              {{ inventory.low_stock|default(0) }}
             </div>
           </div>
           <div class="text-warning">
@@ -88,7 +88,7 @@
               Inventory Value
             </div>
             <div class="h4 mb-0 fw-bold">
-              $847,250
+              {{ inventory.total_value|default(0)|currency }}
             </div>
           </div>
           <div class="text-success">
@@ -109,7 +109,7 @@
               Out of Stock
             </div>
             <div class="h4 mb-0 fw-bold">
-              3
+              {{ inventory.out_of_stock|default(0) }}
             </div>
           </div>
           <div class="text-danger">
@@ -158,110 +158,40 @@
               </tr>
             </thead>
             <tbody>
-              <!-- Sample Oil & Gas Equipment -->
-              <tr>
-                <td class="fw-bold">PUMP-001</td>
-                <td>High-Pressure Acid Pump</td>
-                <td><span class="badge bg-primary">Equipment</span></td>
-                <td>2</td>
-                <td>$125,000</td>
-                <td>$250,000</td>
-                <td><span class="badge bg-success">In Stock</span></td>
-                <td>
-                  <div class="btn-group btn-group-sm">
-                    <button class="btn btn-outline-info"><i class="fas fa-eye"></i></button>
-                    <button class="btn btn-outline-warning"><i class="fas fa-edit"></i></button>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td class="fw-bold">HOSE-150</td>
-                <td>3" High-Pressure Hose (150ft)</td>
-                <td><span class="badge bg-info">Supplies</span></td>
-                <td>5</td>
-                <td>$2,850</td>
-                <td>$14,250</td>
-                <td><span class="badge bg-warning">Low Stock</span></td>
-                <td>
-                  <div class="btn-group btn-group-sm">
-                    <button class="btn btn-outline-info"><i class="fas fa-eye"></i></button>
-                    <button class="btn btn-outline-warning"><i class="fas fa-edit"></i></button>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td class="fw-bold">CHEM-HF</td>
-                <td>Hydrofluoric Acid (15% solution)</td>
-                <td><span class="badge bg-warning">Chemicals</span></td>
-                <td>850</td>
-                <td>$45</td>
-                <td>$38,250</td>
-                <td><span class="badge bg-success">In Stock</span></td>
-                <td>
-                  <div class="btn-group btn-group-sm">
-                    <button class="btn btn-outline-info"><i class="fas fa-eye"></i></button>
-                    <button class="btn btn-outline-warning"><i class="fas fa-edit"></i></button>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td class="fw-bold">VALVE-BOP</td>
-                <td>Blowout Preventer Control Valve</td>
-                <td><span class="badge bg-primary">Equipment</span></td>
-                <td>0</td>
-                <td>$15,750</td>
-                <td>$0</td>
-                <td><span class="badge bg-danger">Out of Stock</span></td>
-                <td>
-                  <div class="btn-group btn-group-sm">
-                    <button class="btn btn-outline-info"><i class="fas fa-eye"></i></button>
-                    <button class="btn btn-outline-danger"><i class="fas fa-shopping-cart"></i></button>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td class="fw-bold">SAND-FRAC</td>
-                <td>Frac Sand 20/40 Mesh (tons)</td>
-                <td><span class="badge bg-secondary">Materials</span></td>
-                <td>2400</td>
-                <td>$125</td>
-                <td>$300,000</td>
-                <td><span class="badge bg-success">In Stock</span></td>
-                <td>
-                  <div class="btn-group btn-group-sm">
-                    <button class="btn btn-outline-info"><i class="fas fa-eye"></i></button>
-                    <button class="btn btn-outline-warning"><i class="fas fa-edit"></i></button>
-                  </div>
-                </td>
-              </tr>
+              {% if inventory.items %}
+                {% for item in inventory.items %}
+                  <tr>
+                    <td class="fw-bold">{{ item.code }}</td>
+                    <td>{{ item.description }}</td>
+                    <td><span class="badge bg-primary">{{ item.category }}</span></td>
+                    <td>{{ item.current_stock }}</td>
+                    <td>{{ item.unit_price|currency }}</td>
+                    <td>{{ item.total_value|currency }}</td>
+                    <td><span class="badge bg-success">{{ item.status }}</span></td>
+                    <td>
+                      <div class="btn-group btn-group-sm">
+                        <button class="btn btn-outline-info"><i class="fas fa-eye"></i></button>
+                        <button class="btn btn-outline-warning"><i class="fas fa-edit"></i></button>
+                      </div>
+                    </td>
+                  </tr>
+                {% endfor %}
+              {% else %}
+                <tr>
+                  <td colspan="8" class="text-center">No data available</td>
+                </tr>
+              {% endif %}
             </tbody>
           </table>
         </div>
         
+        {% if inventory.items %}
         <div class="d-flex justify-content-between align-items-center mt-3">
           <div class="text-muted">
-            Showing 5 of 124 items
+            Showing {{ inventory.items|length }} items
           </div>
-          <nav>
-            <ul class="pagination pagination-sm mb-0">
-              <li class="page-item disabled">
-                <span class="page-link">Previous</span>
-              </li>
-              <li class="page-item active">
-                <span class="page-link">1</span>
-              </li>
-              <li class="page-item">
-                <a class="page-link" href="#">2</a>
-              </li>
-              <li class="page-item">
-                <a class="page-link" href="#">3</a>
-              </li>
-              <li class="page-item">
-                <a class="page-link" href="#">Next</a>
-              </li>
-            </ul>
-          </nav>
         </div>
+        {% endif %}
       </div>
     </div>
   </div>
@@ -309,34 +239,19 @@
       </div>
       <div class="card-body">
         <div class="list-group list-group-flush">
-          <div class="list-group-item d-flex justify-content-between align-items-center">
-            <div>
-              <i class="fas fa-cogs me-2 text-primary"></i>
-              <strong>Equipment</strong>
-            </div>
-            <span class="badge bg-primary rounded-pill">45</span>
-          </div>
-          <div class="list-group-item d-flex justify-content-between align-items-center">
-            <div>
-              <i class="fas fa-flask me-2 text-warning"></i>
-              <strong>Chemicals</strong>
-            </div>
-            <span class="badge bg-warning rounded-pill">28</span>
-          </div>
-          <div class="list-group-item d-flex justify-content-between align-items-center">
-            <div>
-              <i class="fas fa-toolbox me-2 text-info"></i>
-              <strong>Supplies</strong>
-            </div>
-            <span class="badge bg-info rounded-pill">35</span>
-          </div>
-          <div class="list-group-item d-flex justify-content-between align-items-center">
-            <div>
-              <i class="fas fa-cube me-2 text-secondary"></i>
-              <strong>Materials</strong>
-            </div>
-            <span class="badge bg-secondary rounded-pill">16</span>
-          </div>
+          {% if inventory.categories %}
+            {% for cat in inventory.categories %}
+              <div class="list-group-item d-flex justify-content-between align-items-center">
+                <div>
+                  <i class="{{ cat.icon }} me-2 text-{{ cat.color }}"></i>
+                  <strong>{{ cat.name }}</strong>
+                </div>
+                <span class="badge bg-{{ cat.color }} rounded-pill">{{ cat.count }}</span>
+              </div>
+            {% endfor %}
+          {% else %}
+            <p class="text-center mb-0">No data available</p>
+          {% endif %}
         </div>
       </div>
     </div>
@@ -357,24 +272,18 @@
       </div>
       <div class="card-body">
         <div class="row g-3">
-          <div class="col-md-4">
-            <div class="alert alert-danger mb-0">
-              <i class="fas fa-times-circle me-2"></i>
-              <strong>3 items</strong> are out of stock
-            </div>
-          </div>
-          <div class="col-md-4">
-            <div class="alert alert-warning mb-0">
-              <i class="fas fa-exclamation-triangle me-2"></i>
-              <strong>8 items</strong> are running low
-            </div>
-          </div>
-          <div class="col-md-4">
-            <div class="alert alert-info mb-0">
-              <i class="fas fa-clock me-2"></i>
-              <strong>Next audit</strong> due in 15 days
-            </div>
-          </div>
+          {% if inventory.alerts %}
+            {% for alert in inventory.alerts %}
+              <div class="col-md-4">
+                <div class="alert alert-{{ alert.type }} mb-0">
+                  <i class="{{ alert.icon }} me-2"></i>
+                  {{ alert.message }}
+                </div>
+              </div>
+            {% endfor %}
+          {% else %}
+            <p class="text-center mb-0">No alerts</p>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/templates/purchase_orders/index.html
+++ b/templates/purchase_orders/index.html
@@ -46,7 +46,7 @@
               Total PO Value
             </div>
             <div class="h4 mb-0 fw-bold" id="total-po-value">
-              $1,250,000
+              {{ po.total_value|default(0)|currency }}
             </div>
           </div>
           <div class="text-info">
@@ -67,7 +67,7 @@
               Pending Orders
             </div>
             <div class="h4 mb-0 fw-bold" id="pending-orders">
-              12
+              {{ po.pending_orders|default(0) }}
             </div>
           </div>
           <div class="text-warning">
@@ -109,7 +109,7 @@
               Fulfillment Rate
             </div>
             <div class="h4 mb-0 fw-bold" id="fulfillment-rate">
-              94.8%
+              {{ po.completion_rate|default(0)|round(1) }}%
             </div>
           </div>
           <div class="text-primary">
@@ -147,7 +147,7 @@
       <div class="card-body">
         <div class="alert alert-info" role="alert">
           <i class="fas fa-info-circle me-2"></i>
-          <strong>Procurement Status:</strong> 12 orders pending fulfillment with excellent 94.8% completion rate.
+          <strong>Procurement Status:</strong> {{ po.pending_orders|default(0) }} orders pending fulfillment with excellent {{ po.completion_rate|default(0)|round(1) }}% completion rate.
           Strong supplier relationships ensure operational continuity.
         </div>
         
@@ -277,7 +277,7 @@
           <div class="col-md-6">
             <h6 class="fw-bold">Procurement Excellence</h6>
             <p class="text-muted">
-              Our procurement management achieves excellent performance with 94.8% fulfillment rate 
+              Our procurement management achieves excellent performance with {{ po.completion_rate|default(0)|round(1) }}% fulfillment rate
               and 3-day average processing time. Strategic sourcing from top-tier suppliers.
             </p>
           </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -146,7 +146,7 @@
               <strong>Total Transactions</strong>
               <br><small class="text-muted">All accounts combined</small>
             </div>
-            <span class="badge bg-success rounded-pill">594</span>
+              <span class="badge bg-success rounded-pill">{{ stats.total_transactions|default(0) }}</span>
           </div>
           <div class="list-group-item d-flex justify-content-between align-items-center">
             <div>


### PR DESCRIPTION
## Summary
- Derive financial summary KPIs from real bank transactions and feed them to the dashboard templates with defaults for empty datasets.
- Surface accounts receivable/payable, purchase order, and inventory KPIs dynamically using SQLAlchemy queries and guard templates against missing data.
- Add cash flow trend calculations and replace hardcoded trend badges with data-driven values.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_689a95b627288323a2fe376e2fedc9e0