### PR TITLE
UI: Flexy pilot (parallel layout + Financial Summary)

### DIFF
--- a/static/vendor/flexy/css/flexy-styles.min.css
+++ b/static/vendor/flexy/css/flexy-styles.min.css
@@ -1,0 +1,9 @@
+/*! Flexy Bootstrap Lite 1.0.0 */
+body{font-family:"Poppins",sans-serif;}
+.page-wrapper{display:flex;width:100%;min-height:100vh;}
+.left-sidebar{width:260px;background:#fff;box-shadow:0 0 30px rgba(31,45,61,.1);}
+.body-wrapper{flex:1;display:flex;flex-direction:column;min-width:0;}
+.sidebar-nav{list-style:none;padding-left:0;margin:0;}
+.sidebar-nav .sidebar-item{display:block;}
+.sidebar-nav .sidebar-link{display:flex;align-items:center;padding:.5rem 1rem;color:#6c757d;text-decoration:none;transition:all .2s;}
+.sidebar-nav .sidebar-link:hover{color:#000;background:rgba(0,0,0,.04);}

--- a/static/vendor/flexy/js/app.min.js
+++ b/static/vendor/flexy/js/app.min.js
@@ -1,0 +1,6 @@
+/*! Flexy Bootstrap Lite */
+document.addEventListener("DOMContentLoaded",function(){
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function(el){
+    new bootstrap.Tooltip(el);
+  });
+});

--- a/static/vendor/flexy/js/dashboard.js
+++ b/static/vendor/flexy/js/dashboard.js
@@ -1,0 +1,2 @@
+/*! Flexy Dashboard placeholder */
+console.log("Flexy dashboard loaded");

--- a/static/vendor/flexy/js/sidebarmenu.js
+++ b/static/vendor/flexy/js/sidebarmenu.js
@@ -1,0 +1,11 @@
+/*! Flexy Bootstrap Lite - Sidebar Menu */
+document.addEventListener("DOMContentLoaded",function(){
+  var toggler=document.querySelector(".sidebartoggler");
+  var wrapper=document.getElementById("main-wrapper");
+  if(toggler&&wrapper){
+    toggler.addEventListener("click",function(e){
+      e.preventDefault();
+      wrapper.classList.toggle("show-sidebar");
+    });
+  }
+});

--- a/static/vendor/flexy/libs/apexcharts/dist/apexcharts.min.js
+++ b/static/vendor/flexy/libs/apexcharts/dist/apexcharts.min.js
@@ -1,0 +1,6 @@
+/*! ApexCharts placeholder */
+window.ApexCharts=function(el,opts){
+  this.render=function(){
+    console.warn('ApexCharts placeholder: real library not included');
+  };
+};

--- a/static/vendor/flexy/libs/simplebar/dist/simplebar.min.js
+++ b/static/vendor/flexy/libs/simplebar/dist/simplebar.min.js
@@ -1,0 +1,4 @@
+/*! SimpleBar placeholder */
+window.SimpleBar=function(el,opts){
+  console.warn('SimpleBar placeholder');
+};

--- a/templates/components/flexy_navbar.html
+++ b/templates/components/flexy_navbar.html
@@ -1,0 +1,13 @@
+<header class="app-header">
+  <nav class="navbar navbar-expand-lg navbar-light px-3">
+    <ul class="navbar-nav">
+      <li class="nav-item d-block d-xl-none">
+        <a class="nav-link sidebartoggler" id="headerCollapse"><i class="fa fa-bars"></i></a>
+      </li>
+    </ul>
+    <div class="ms-auto d-flex align-items-center gap-3">
+      <span class="text-muted small">Welcome, {{ (current_user.first_name or current_user.username) if current_user.is_authenticated else 'User' }}</span>
+      <a href="{{ url_for('auth.logout') }}" class="btn btn-outline-primary btn-sm">Logout</a>
+    </div>
+  </nav>
+</header>

--- a/templates/components/flexy_sidebar.html
+++ b/templates/components/flexy_sidebar.html
@@ -1,0 +1,49 @@
+<nav class="sidebar-nav">
+  <ul id="sidebarnav">
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('main.dashboard') }}">
+        <i class="fa fa-gauge-high me-2"></i><span class="hide-menu">Dashboard</span>
+      </a>
+    </li>
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('cash_flow.enhanced_dashboard') }}">
+        <i class="fa fa-chart-line me-2"></i><span class="hide-menu">Enhanced Dashboard</span>
+      </a>
+    </li>
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('main.financial_summary') }}">
+        <i class="fa fa-coins me-2"></i><span class="hide-menu">Financial Summary</span>
+      </a>
+    </li>
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('cash_flow.index') }}">
+        <i class="fa fa-water me-2"></i><span class="hide-menu">Cash Flow</span>
+      </a>
+    </li>
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('accounts_receivable.index') }}">
+        <i class="fa fa-file-invoice-dollar me-2"></i><span class="hide-menu">Accounts Receivable</span>
+      </a>
+    </li>
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('accounts_payable.index') }}">
+        <i class="fa fa-credit-card me-2"></i><span class="hide-menu">Accounts Payable</span>
+      </a>
+    </li>
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('purchase_orders.index') }}">
+        <i class="fa fa-cart-shopping me-2"></i><span class="hide-menu">Purchase Orders</span>
+      </a>
+    </li>
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('main.inventory') }}">
+        <i class="fa fa-boxes-stacked me-2"></i><span class="hide-menu">Inventory</span>
+      </a>
+    </li>
+    <li class="sidebar-item">
+      <a class="sidebar-link" href="{{ url_for('main.settings') }}">
+        <i class="fa fa-gear me-2"></i><span class="hide-menu">Settings</span>
+      </a>
+    </li>
+  </ul>
+</nav>

--- a/templates/dashboard/financial_summary.html
+++ b/templates/dashboard/financial_summary.html
@@ -1,11 +1,8 @@
-{% extends "base.html" %}
+{% extends "layouts/flexy_base.html" %}
 
-{% block page_title %}Financial Summary{% endblock %}
+{% block title %}Financial Summary · AcidTech{% endblock %}
 
-{% block breadcrumbs %}
-<li class="breadcrumb-item"><a href="{{ url_for('main.dashboard') }}" class="text-decoration-none">Dashboard</a></li>
-<li class="breadcrumb-item active">Financial Summary</li>
-{% endblock %}
+
 
 {% block content %}
 
@@ -292,7 +289,7 @@
 
 {% endblock %}
 
-{% block scripts %}
+{% block extra_js %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Add any executive dashboard specific JavaScript here

--- a/templates/layouts/flexy_base.html
+++ b/templates/layouts/flexy_base.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}AcidTech{% endblock %}</title>
+
+  <!-- CSS del proyecto (Bootstrap/FA actuales ya presentes en base global) -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+  <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
+  {% if self.extra_css %}{% block extra_css %}{% endblock %}{% endif %}
+
+  <!-- Flexy CSS al final para evitar colisiones -->
+  <link rel="stylesheet" href="{{ url_for('static', filename='vendor/flexy/css/flexy-styles.min.css') }}" />
+</head>
+<body>
+  <div class="page-wrapper" id="main-wrapper" data-layout="vertical">
+    <aside class="left-sidebar">
+      {% include 'components/flexy_sidebar.html' %}
+    </aside>
+
+    <div class="body-wrapper">
+      {% include 'components/flexy_navbar.html' %}
+
+      <div class="container-fluid py-3">
+        {% block content %}{% endblock %}
+      </div>
+    </div>
+  </div>
+
+  <!-- JS del proyecto (Bootstrap bundle) -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/navigation.js') }}"></script>
+
+  <!-- Flexy libs opcionales (no rompen si existen): -->
+  <script src="{{ url_for('static', filename='vendor/flexy/js/sidebarmenu.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendor/flexy/js/app.min.js') }}"></script>
+  <!-- Si en esta vista se usará ApexCharts, se añadirá en el template específico -->
+
+  {% if self.extra_js %}{% block extra_js %}{% endblock %}{% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flexy asset scaffold under `static/vendor/flexy`
- create parallel layout `flexy_base.html` with sidebar & navbar components
- migrate `dashboard/financial_summary.html` to new Flexy layout
- replace Flexy asset placeholders with minimal stubs for CSS/JS

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689c071a85348323ae4bb8cc27030f28